### PR TITLE
Add macOS standalone batch-build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Unity
+/[Bb]uild
 /[Bb]uilds
 /[Ll]ibrary
 /[Ll]ogs
@@ -18,6 +19,9 @@
 
 # Rider
 /**/.idea
+
+# VS Code
+/.vscode
 
 # Copilot
 /.github

--- a/Assets/Scripts/Editor/MacBuildScript.cs
+++ b/Assets/Scripts/Editor/MacBuildScript.cs
@@ -1,0 +1,101 @@
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Build.Reporting;
+using UnityEngine;
+
+// Batch-mode build helper for the macOS Standalone target.
+//
+// CLI usage:
+//   Unity -batchmode -nographics -quit \
+//     -projectPath . \
+//     -buildTarget OSXUniversal \
+//     -executeMethod MacBuildScript.BuildFromCli \
+//     [-arch arm64|x64|universal] \
+//     [-outDir Build/Mac]
+//
+// Defaults: arch=universal, outDir=$PWD/Build/Mac
+//
+// The script only configures the macOS architecture for this build; it
+// intentionally does not modify scripting backend, scripting defines or
+// the bundle identifier — those are owned by ProjectSettings.
+public static class MacBuildScript
+{
+	const int ArchX64 = 0;
+	const int ArchARM64 = 1;
+	const int ArchUniversal = 2;
+
+	[MenuItem("Build/macOS (Apple Silicon)")]
+	public static void MenuBuildArm64()
+	{
+		Run(ArchARM64);
+	}
+
+	[MenuItem("Build/macOS (Universal)")]
+	public static void MenuBuildUniversal()
+	{
+		Run(ArchUniversal);
+	}
+
+	public static void BuildFromCli()
+	{
+		int arch = ArchUniversal;
+		string outDir = null;
+		string[] args = System.Environment.GetCommandLineArgs();
+		for(int i = 0; i < args.Length; ++i)
+		{
+			if(args[i] == "-arch" && i + 1 < args.Length)
+			{
+				string v = args[i + 1].ToLowerInvariant();
+				if(v == "arm64") arch = ArchARM64;
+				else if(v == "x64" || v == "x86_64") arch = ArchX64;
+				else if(v == "universal") arch = ArchUniversal;
+			}
+			else if(args[i] == "-outDir" && i + 1 < args.Length)
+			{
+				outDir = args[i + 1];
+			}
+		}
+		Run(arch, outDir);
+	}
+
+	static void Run(int arch, string outDir = null)
+	{
+		if(string.IsNullOrEmpty(outDir))
+			outDir = Path.Combine(Directory.GetCurrentDirectory(), "Build", "Mac");
+		Directory.CreateDirectory(outDir);
+
+		string appName = SanitizeFileName(PlayerSettings.productName) + ".app";
+		string outPath = Path.Combine(outDir, appName);
+
+		PlayerSettings.SetArchitecture(BuildTargetGroup.Standalone, arch);
+
+		string[] scenes = EditorBuildSettings.scenes
+			.Where(s => s.enabled)
+			.Select(s => s.path)
+			.ToArray();
+
+		BuildPlayerOptions options = new BuildPlayerOptions
+		{
+			scenes = scenes,
+			locationPathName = outPath,
+			target = BuildTarget.StandaloneOSX,
+			targetGroup = BuildTargetGroup.Standalone,
+			options = BuildOptions.None,
+		};
+
+		BuildReport report = BuildPipeline.BuildPlayer(options);
+		BuildSummary summary = report.summary;
+		Debug.Log($"[MacBuildScript] Result={summary.result}, Output={outPath}, Size={summary.totalSize}, Time={summary.totalTime}");
+
+		if(Application.isBatchMode)
+			EditorApplication.Exit(summary.result == BuildResult.Succeeded ? 0 : 1);
+	}
+
+	static string SanitizeFileName(string name)
+	{
+		foreach(char c in Path.GetInvalidFileNameChars())
+			name = name.Replace(c, '_');
+		return name;
+	}
+}

--- a/Assets/Scripts/Editor/MacBuildScript.cs.meta
+++ b/Assets/Scripts/Editor/MacBuildScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f361a286fe00542f198a5308508de144
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要 / Summary

Adds an Editor helper script to build the project for the macOS Standalone target from the command line in batch mode. Useful for contributors who want to produce a Mac `.app` from source without opening the Editor.

为非 Steam 渠道的玩家在自己电脑上构建 macOS 版本提供了一键 CLI 入口；也可作为将来上 Mac 平台的基础。

## 用法 / Usage

CLI:
```bash
Unity -batchmode -nographics -quit \
  -projectPath . \
  -buildTarget OSXUniversal \
  -executeMethod MacBuildScript.BuildFromCli \
  -arch universal \
  -outDir Build/Mac
```

`-arch` 接受 `arm64` / `x64` / `universal`（默认 universal）。
`-outDir` 默认 `$PWD/Build/Mac`。

Editor 内也可以直接走菜单 `Build > macOS (Apple Silicon)` 或 `Build > macOS (Universal)`。

## 改动范围 / Scope

- 新增 `Assets/Scripts/Editor/MacBuildScript.cs`（约 100 行，纯 Editor 脚本，运行时无任何影响）
- `.gitignore` 加 `/Build` 和 `/.vscode`

**有意不修改任何 `ProjectSettings.asset`、scripting backend、scripting define、bundle identifier**，避免和您的 Steam 发行流程相互打架。脚本只做一件事：把您当前 `ProjectSettings` 的配置 + 命令行指定的架构，喂给 `BuildPipeline.BuildPlayer`。

## 测试 / Testing

在 Unity 2022.3.62f3 (Apple Silicon) 上验证过：
- ✅ `MacBuildScript.MenuBuildArm64` —— 出 arm64 .app
- ✅ `MacBuildScript.MenuBuildUniversal` —— 出 Universal Binary
- ✅ CLI batch mode 同上
- ✅ 不影响 Windows 工程的打开和构建

## 背景 / Context

我先前在私下与您沟通过想给项目做 macOS 构建支持，您表示同意我做二次开发。这个 PR 是把那次工作中**真正可以回馈上游的部分**单独切了出来 —— 即一个不依赖任何下游配置的、通用的 Mac 批处理构建脚本。

不强求合并，您看着合适再处理就行。如果您觉得方向不对也可以直接 close，我自己 fork 那边已经在用了。